### PR TITLE
Prepare for renovate bot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    "config:recommended"
+  ],
+  "regexManagers": [
+    {
+      "datasourceTemplate": "docker",
+      "fileMatch": [
+        "(^|/)Chart\\.yaml$"
+      ],
+      "matchStrings": [
+        "#\\s*renovate: image=(?<depName>.*?)\\s+appVersion:\\s*[\"']?(?<currentValue>[\\w+\\.\\-]*)"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -25,8 +25,11 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v3
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_TOKEN: "${{ secrets.ELEMENT_BOT_TOKEN }}"
+          CR_SKIP_EXISTING: true

--- a/charts/element-call/Chart.yaml
+++ b/charts/element-call/Chart.yaml
@@ -6,8 +6,10 @@ type: application
 
 # This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.3
+version: "0.1.3"
 
 # This version number should be incremented each time you make changes
 # to the application.
+# Track the appVersion based on the image:
+# renovate: image=ghcr.io/vector-im/element-call
 appVersion: "v0.3.13"

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -6,4 +6,6 @@ maintainers:
   - name: Element SRE Team
 
 version: "0.82.0"
+# Track the appVersion based on the image:
+# renovate: image=ghost
 appVersion: "5.38.0-alpine"


### PR DESCRIPTION
Add renovate config
 - Changes tag if present
 - Tracks the same docker image version in appversion using regex
    
Incrementing the `Chart.yaml` version is tricker than expected, postupgrade isn't available using the not-self-hosted app, and the docker tags do not follow SemVer or we could just track that. For now we can manually bump as we do not enable automerge. If we self host this we can use postupgrade to increment the version for our own charts.
